### PR TITLE
#161996514 add get user_id from logged in user

### DIFF
--- a/backend/my_app/api/v1/__init__.py
+++ b/backend/my_app/api/v1/__init__.py
@@ -15,4 +15,3 @@ api.add_resource(CancelOrder, "/parcels/<int:parcel_id>/cancel")
 api.add_resource(UserOrders, "/users/<user_id>/parcels")
 api.add_resource(Register, "/register")
 api.add_resource(Login, "/login")
-

--- a/backend/my_app/api/v1/models/parcel.py
+++ b/backend/my_app/api/v1/models/parcel.py
@@ -61,7 +61,7 @@ class ParcelModel:
         """
         parcel = self.get_specific_parcel(parcel_id)
 
-        if parcel is not None and parcel_id == data['parcel_id']:
+        if parcel is not None and parcel_id == int(data['parcel_id']):
             parcel['status'] = "canceled"
             return parcel
         return None

--- a/backend/my_app/api/v1/models/parcel.py
+++ b/backend/my_app/api/v1/models/parcel.py
@@ -6,7 +6,7 @@ class ParcelModel:
     """This class creates, gets, updates a parcel oerder"""
     parcels = []
 
-    def add_parcel(self, data):
+    def add_parcel(self, data, user_id):
         """
         This method creates a new parcel delivery order
 
@@ -14,11 +14,11 @@ class ParcelModel:
         :return: returns a dictionary object of a newly created parcel
                 order
         """
-        sender_id = data['sender_id']
+        sender_id = user_id
+        parcel_details = data['parcel_details']
         pickup_location = data['pickup_location']
         destination = data['destination']
         weight = data['weight']
-        status = data['status']
         price = data['price']
 
         parcel_id = uuid.uuid4().int >> 64
@@ -26,10 +26,11 @@ class ParcelModel:
         parcel = {
             'parcel_id': parcel_id,
             'sender_id': sender_id,
+            'parcel_details': parcel_details,
             'pickup_location': pickup_location,
             'destination': destination,
             'weight': weight,
-            'status': status,
+            'status': "pending delivery",
             'price': price
         }
 
@@ -60,8 +61,8 @@ class ParcelModel:
         """
         parcel = self.get_specific_parcel(parcel_id)
 
-        if parcel is not None:
-            parcel['status'] = data['status']
+        if parcel is not None and parcel_id == data['parcel_id']:
+            parcel['status'] = "canceled"
             return parcel
         return None
 

--- a/backend/my_app/api/v1/schemas.py
+++ b/backend/my_app/api/v1/schemas.py
@@ -4,7 +4,8 @@ from .validators import is_empty
 
 
 class UserPostSchema(Schema):
-    """ This class creates a schema to validate user json post data"""
+    """This class creates a validation schema to validate user json post data.
+    """
     name = fields.String(required=True, validate=is_empty)
     email = fields.Email(required=True)
     password = fields.String(required=True, validate=is_empty)
@@ -12,16 +13,19 @@ class UserPostSchema(Schema):
 
 
 class UserLoginSchema(Schema):
-    """ This class creates a schema to validate user json post data"""
+    """T
+    his class creates a validation schema to validate user json post data.
+    """
     email = fields.Email(required=True)
     password = fields.String(required=True, validate=is_empty)
 
 
 class ParceCreateSchema(Schema):
-    """ This class creates a schema for creating a ne parcel order"""
-    sender_id = fields.Integer(required=True)
+    """
+    This class creates a validation schema for creating a new parcel order.
+    """
+    parcel_details = fields.String(required=True, validate=is_empty)
     pickup_location = fields.String(required=True, validate=is_empty)
     destination = fields.String(required=True, validate=is_empty)
     weight = fields.String(required=True, validate=is_empty)
-    status = fields.String(required=True, validate=is_empty)
     price = fields.String(required=True, validate=is_empty)

--- a/backend/my_app/api/v1/schemas.py
+++ b/backend/my_app/api/v1/schemas.py
@@ -29,3 +29,10 @@ class ParceCreateSchema(Schema):
     destination = fields.String(required=True, validate=is_empty)
     weight = fields.String(required=True, validate=is_empty)
     price = fields.String(required=True, validate=is_empty)
+
+
+class ParceCancelSchema(Schema):
+    """
+    This class creates a validation schema for canceling a new parcel order.
+    """
+    parcel_id = fields.Integer(required=True)

--- a/backend/my_app/api/v1/views/auth_views.py
+++ b/backend/my_app/api/v1/views/auth_views.py
@@ -33,13 +33,12 @@ class Register(Resource):
             return make_response(jsonify({
                 "message": "User already exists"
             }), 409)
-        else:
-            new_user = user.add_user(data)
-            return make_response(jsonify({
-                "message": "User saved",
-                "status": "Created",
-                "data": new_user
-            }), 201)
+        new_user = user.add_user(data)
+        return make_response(jsonify({
+            "message": "User saved",
+            "status": "Created",
+            "data": new_user
+        }), 201)
 
 
 class Login(Resource):

--- a/backend/my_app/api/v1/views/parcel_views.py
+++ b/backend/my_app/api/v1/views/parcel_views.py
@@ -7,7 +7,7 @@ from flask_restful import Resource
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..models.parcel import ParcelModel
 from ..models.user_model import User
-from ..schemas import ParceCreateSchema
+from ..schemas import ParceCreateSchema, ParceCancelSchema
 from ..validators import validate_json
 
 
@@ -31,12 +31,10 @@ class Parcels(Resource):
         is_valid = validate_json(schema, data)
 
         if is_valid is not None:
-            return make_response(jsonify(
-                {
-                    "Message": is_valid,
-                    "status": "Bad Request"
-                }
-            ), 400)
+            return make_response(jsonify({
+                "Message": is_valid,
+                "status": "Bad Request"
+            }), 400)
 
         parcel = ParcelModel()
         my_parcel = parcel.add_parcel(data, user_id)
@@ -108,25 +106,29 @@ class CancelOrder(Resource):
         :param parcel_id:
         :return: Returns a json response
         """
-
+        schema = ParceCancelSchema()
         parcel = ParcelModel()
         data = request.get_json() or {}
+
+        check_valid = validate_json(schema, data)
+
+        if check_valid is not None:
+            return make_response(jsonify({
+                "Message": check_valid,
+                "status": "Bad Request"
+            }), 400)
         change = parcel.cancel_order(parcel_id, data)
 
         if change is not None:
-            return make_response(jsonify(
-                {
-                    "Message": "success",
-                    "status": "Accepted",
-                    "data": change
-                }
-            ), 202)
-        return make_response(jsonify(
-            {
-                "Message": "The order requested does not exist",
-                "status": "Not Found"
-            }
-        ), 404)
+            return make_response(jsonify({
+                "Message": "success",
+                "status": "Accepted",
+                "data": change
+            }), 202)
+        return make_response(jsonify({
+            "Message": "The order requested does not exist",
+            "status": "Not Found"
+        }), 404)
 
 
 class UserOrders(Resource):

--- a/backend/my_app/api/v1/views/parcel_views.py
+++ b/backend/my_app/api/v1/views/parcel_views.py
@@ -4,8 +4,9 @@ Creates views for parcels. These are POST, GET, PUT
 
 from flask import request, make_response, jsonify
 from flask_restful import Resource
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..models.parcel import ParcelModel
+from ..models.user_model import User
 from ..schemas import ParceCreateSchema
 from ..validators import validate_json
 
@@ -20,6 +21,11 @@ class Parcels(Resource):
         """Saves a new parcel item
         :return: Returns a json response
         """
+        user = User()
+        user_email = get_jwt_identity()
+        get_user = user.get_user(user_email)
+        user_id = get_user['user_id']
+
         schema = ParceCreateSchema()
         data = request.get_json() or {}
         is_valid = validate_json(schema, data)
@@ -33,7 +39,7 @@ class Parcels(Resource):
             ), 400)
 
         parcel = ParcelModel()
-        my_parcel = parcel.add_parcel(data)
+        my_parcel = parcel.add_parcel(data, user_id)
 
         payload = {
             'status': 'Created',

--- a/backend/my_app/api/v1/views/parcel_views.py
+++ b/backend/my_app/api/v1/views/parcel_views.py
@@ -73,22 +73,17 @@ class SpecificParcel(Resource):
         try:
             parcel_id = int(parcel_id)
         except Exception:
-            return make_response(
-                jsonify(
-                    {
-                        "Message": "Please provide a valid parcel id(int)",
-                        "status": "Bad request"
-                    }
-                ), 400)
+            return make_response(jsonify({
+                "Message": "Please provide a valid parcel id(int)",
+                "status": "Bad request"
+            }), 400)
         parcel = ParcelModel()
 
         single_parcel = parcel.get_specific_parcel(parcel_id)
         if single_parcel is not None:
-            return make_response(jsonify(
-                {
-                    "parcel": single_parcel, "status": "OK"
-                }
-            ), 200)
+            return make_response(jsonify({
+                "parcel": single_parcel, "status": "OK"
+            }), 200)
         return make_response(
             jsonify({
                 "Parcel": "No parcel found",

--- a/backend/my_app/tests/v1/data.py
+++ b/backend/my_app/tests/v1/data.py
@@ -4,6 +4,7 @@
 create_test_order = {
     "sender_id": 1,
     "parcel_id": 1,
+    "parcel_details": "Spare parts",
     "pickup_location": "Nakuru",
     "destination": "Eldoret",
     "weight": "10KG",
@@ -20,24 +21,19 @@ create_test_user = {
 
 # Data for parcel views
 create_order = {
-    "sender_id": 1,
+    "parcel_details": "Spare parts",
     "pickup_location": "Nakuru",
     "destination": "Eldoret",
     "weight": "10KG",
-    "status": "pending delivery",
     "price": "KES500"
 }
 
 cancel_order = {
-    "sender_id": 1,
-    "pickup_location": "Nakuru",
-    "destination": "Eldoret",
-    "weight": "10KG",
-    "status": "canceled"
+    "parcel_id": 1
 }
 
 empty_string = {
-    "sender_id": 1,
+    "parcel_details": "",
     "pickup_location": "",
     "destination": "Eldoret",
     "weight": "10KG",

--- a/backend/my_app/tests/v1/data.py
+++ b/backend/my_app/tests/v1/data.py
@@ -32,6 +32,10 @@ cancel_order = {
     "parcel_id": 1
 }
 
+cancel_order_invalid = {
+    "parcel_id": ""
+}
+
 empty_string = {
     "parcel_details": "",
     "pickup_location": "",

--- a/backend/my_app/tests/v1/test_parcel_views.py
+++ b/backend/my_app/tests/v1/test_parcel_views.py
@@ -2,8 +2,7 @@
 This test class tests the parcel_views
 """
 from flask import json
-from .data import (create_order, cancel_order,
-                   empty_data, empty_string)
+from .data import (create_order, cancel_order, empty_data, empty_string)
 
 
 class TestParcelViews(object):
@@ -111,6 +110,18 @@ class TestParcelViews(object):
         assert 'Please provide a valid parcel id(int)' in str(
             res_data['Message'])
 
+    def test_found_users_all_orders(self, client, auth_token):
+        """Test a specific users all orders are found"""
+
+        response = client.get(
+            "/api/v1/users/1/parcels",
+            headers=dict(Authorization="Bearer " + auth_token),
+        )
+        res_data = json.loads(response.get_data(as_text=True))
+        assert response.status_code == 200
+        assert 'OK' in res_data['status']
+        assert 'pending delivery' in str(res_data['Parcels'])
+
     def test_cancel_an_order_if_order_exist(self, client, auth_token):
         """Test canceling an order if order exists"""
 
@@ -139,23 +150,12 @@ class TestParcelViews(object):
         assert 'Not Found' in res_data['status']
         assert 'The order requested does not exist' in str(res_data['Message'])
 
-    def test_found_users_all_orders(self, client, auth_token):
-        """Test a specific users all orders are found"""
-
-        response = client.get(
-            "/api/v1/users/1/parcels",
-            headers=dict(Authorization="Bearer " + auth_token),)
-        res_data = json.loads(response.get_data(as_text=True))
-        assert response.status_code == 200
-        assert 'OK' in res_data['status']
-        assert 'pending delivery' in str(res_data['Parcels'])
-
     def test_not_found_order_for_user(self, client, auth_token):
         """Test a specific user's orders none are found"""
 
         response = client.get(
             "/api/v1/users/10/parcels",
-            headers=dict(Authorization="Bearer " + auth_token),)
+            headers=dict(Authorization="Bearer " + auth_token))
         res_data = json.loads(response.get_data(as_text=True))
         assert response.status_code == 404
         assert 'Not Found' in res_data['status']
@@ -166,7 +166,7 @@ class TestParcelViews(object):
 
         response = client.get(
             "/api/v1/users/a/parcels",
-            headers=dict(Authorization="Bearer " + auth_token),)
+            headers=dict(Authorization="Bearer " + auth_token))
         res_data = json.loads(response.get_data(as_text=True))
         assert response.status_code == 400
         assert 'Bad request' in res_data['status']

--- a/backend/my_app/tests/v1/test_parcel_views.py
+++ b/backend/my_app/tests/v1/test_parcel_views.py
@@ -2,7 +2,8 @@
 This test class tests the parcel_views
 """
 from flask import json
-from .data import (create_order, cancel_order, empty_data, empty_string)
+from .data import (create_order, cancel_order, empty_data,
+                   empty_string, cancel_order_invalid)
 
 
 class TestParcelViews(object):
@@ -135,6 +136,20 @@ class TestParcelViews(object):
         assert response.status_code == 202
         assert 'Accepted' in res_data['status']
         assert 'canceled' in str(res_data['data'])
+
+    def test_invalid_data_on_cancel(self, client, auth_token):
+        """Test canceling an order if order exists"""
+
+        response = client.put(
+            "api/v1/parcels/1/cancel",
+            data=json.dumps(cancel_order_invalid),
+            headers=dict(Authorization="Bearer " + auth_token),
+            content_type='application/json;charset=utf-8')
+
+        res_data = json.loads(response.get_data(as_text=True))
+        assert response.status_code == 400
+        assert 'Bad Request' in res_data['status']
+        assert 'Not a valid integer.' in str(res_data['Message'])
 
     def test_cancel_an_order_if_order_doesnt_exist(self, client, auth_token):
         """Test canceling an order if order doesn't exists"""


### PR DESCRIPTION
#### What does this PR do?
Add user_id automatically when creating a new parcel 

#### Description of Task to be completed?
Get user_id to automatically be added to a new parcel delivery order from logged in user.
Set default parcel status to `pending_delivery`.
Only need a parcel Id to cancel an order.
Add parcel details to data to be posted.

#### How should this be manually tested?
Clone this repo
Set up a Flask environment by running pip install on requirements.txt on a virtual environment.
Run flask run
Post jason data to the endpoint.
Register, login, then create a new parcel order.
example data:
```
{
	"parcel_details":"My simple details",
	"pickup_location":"Nakuru",
	"destination":"nakuru",
	"weight":"3KG",
	"price":"KES1500"
}
```
One should get a similar output to this:
```
{
    "data": {
        "destination": "nakuru",
        "parcel_details": "My simple details",
        "parcel_id": 1275551150072285370,
        "pickup_location": "Nakuru",
        "price": "KES1500",
        "sender_id": 17598243265267977586,
        "status": "pending delivery",
        "weight": "3KG"
    },
    "message": "Parcel Created",
    "status": "Created"
}
```

#### Any background context you want to provide?
Had a bug where a user had to include the _user_id_ when creating a parcel order in the post data

#### What are the relevant pivotal tracker stories?
#161996514