### PR TITLE
#162031494 add admin edit status endpoint and tests

### DIFF
--- a/backend/my_app/api/v2/__init__.py
+++ b/backend/my_app/api/v2/__init__.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 from flask_restful import Api
 from .views.auth_views import Register, Login
-from .views.parcel_views import Parcels
+from .views.parcel_views import Parcels, ChangeStatus
 
 version2_bp_auth = Blueprint('api_v2', __name__)
 v2_bp = Blueprint('api_routes_v2', __name__)
@@ -12,3 +12,4 @@ api_v2 = Api(v2_bp)
 api_auth_v2.add_resource(Register, '/auth/signup')
 api_auth_v2.add_resource(Login, '/auth/login')
 api_v2.add_resource(Parcels, '/parcels')
+api_v2.add_resource(ChangeStatus, '/parcels/<parcel_id>/status')

--- a/backend/my_app/api/v2/models/parcel.py
+++ b/backend/my_app/api/v2/models/parcel.py
@@ -57,3 +57,16 @@ class ParcelModel:
         cursor.execute(query)
         parcels = cursor.fetchall()
         return parcels
+
+    def change_status(self, parcel_id):
+        """This function changes the status of a parcel"""
+        cursor = self.db.cursor(cursor_factory=RealDictCursor)
+        query = """UPDATE parcels
+                   SET status = '{}'
+                   WHERE parcel_id = {}
+                   AND status = '{}'
+                   """.format('delivered',
+                              parcel_id,
+                              'pending delivery')
+        cursor.execute(query)
+        return self.db.commit()

--- a/backend/my_app/api/v2/views/parcel_views.py
+++ b/backend/my_app/api/v2/views/parcel_views.py
@@ -31,17 +31,12 @@ class Parcels(Resource):
         is_valid = validate_json(schema, data)
 
         if is_valid is not None:
-            return make_response(jsonify({
-                "Message": is_valid
-            }), 400)
+            return make_response(jsonify({"Message": is_valid}), 400)
 
         parcel = ParcelModel()
         my_parcel = parcel.add_parcel(data, user_id)
 
-        payload = {
-            "Message": "Parcel Created",
-            "data": my_parcel
-        }
+        payload = {"Message": "Parcel Created", "data": my_parcel}
         res = make_response(jsonify(payload), 201)
         return res
 
@@ -54,10 +49,39 @@ class Parcels(Resource):
         check_role = user.check_admin(user_email)
 
         if not check_role:
-            return make_response(jsonify({
-                "Message": "You are not authorised to access this resource"
-            }), 403)
+            return make_response(
+                jsonify({
+                    "Message":
+                    "You are not authorised to access this resource"
+                }), 403)
         parcels = parcel.get_all()
-        return make_response(jsonify({
-            "Data": parcels
-        }), 200)
+        return make_response(jsonify({"Data": parcels}), 200)
+
+
+class ChangeStatus(Resource):
+    """
+    This class changes the status of a parcel order from
+    pending delivery to delivered
+    """
+
+    @jwt_required
+    def put(self, parcel_id):
+        """This function allows admin to change status of all parcels"""
+        parcel = ParcelModel()
+        print(parcel_id)
+
+        user = User()
+        user_email = get_jwt_identity()
+        check_role = user.check_admin(user_email)
+
+        if not check_role:
+            return make_response(
+                jsonify({
+                    "Message":
+                    "You are not authorised to access this resource"
+                }), 403)
+        parcel.change_status(parcel_id)
+        return make_response(
+            jsonify({
+                "Message": "Successfully updated status"
+            }), 202)

--- a/backend/my_app/tests/v2/test_parcels.py
+++ b/backend/my_app/tests/v2/test_parcels.py
@@ -77,3 +77,22 @@ class TestParcelViews(object):
         assert response.status_code == 403
         assert 'You are not authorised to access this resource' in str(
             res_data['Message'])
+
+    def test_admin_change_status(self, client, admin_token):
+        response = client.put(
+            "/api/v2/parcels/1/status",
+            headers=dict(Authorization="Bearer " + admin_token))
+
+        res_data = json.loads(response.get_data(as_text=True))
+        assert response.status_code == 202
+        assert 'Successfully updated status' in str(res_data['Message'])
+
+    def test_non_admin_change_status(self, client, auth_token):
+        response = client.put(
+            "/api/v2/parcels/1/status",
+            headers=dict(Authorization="Bearer " + auth_token))
+
+        res_data = json.loads(response.get_data(as_text=True))
+        assert response.status_code == 403
+        assert 'You are not authorised to access this resource' in str(
+            res_data['Message'])


### PR DESCRIPTION
#### What does this PR do?
Add an endpoint to change parcel order status

#### Description of Task to be completed?
Create an endpoint for only an admin to change the status of a parcel order
`/parcels/<parcel_id>/status` - `PUT`

#### How should this be manually tested?
- on a running instance of the app and access the url as shown above.   

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162031494](https://www.pivotaltracker.com/story/show/162031494)

#### Screenshot
![pr8](https://user-images.githubusercontent.com/5704600/48867777-67889500-ede8-11e8-81a7-e86793252622.png)
