### PR TITLE
#162031487 create a change destination endpoint

### DIFF
--- a/backend/my_app/api/v2/__init__.py
+++ b/backend/my_app/api/v2/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint
 from flask_restful import Api
 from .views.auth_views import Register, Login
 from .views.parcel_views import (Parcels, ChangeStatus,
-                                 ChangePresentLocation)
+                                 ChangePresentLocation, ChangeDestination)
 
 version2_bp_auth = Blueprint('api_v2', __name__)
 v2_bp = Blueprint('api_routes_v2', __name__)
@@ -15,3 +15,4 @@ api_auth_v2.add_resource(Login, '/auth/login')
 api_v2.add_resource(Parcels, '/parcels')
 api_v2.add_resource(ChangeStatus, '/parcels/<parcel_id>/status')
 api_v2.add_resource(ChangePresentLocation, '/parcels/<parcel_id>/presentLocation')
+api_v2.add_resource(ChangeDestination, '/parcels/<parcel_id>/destination')

--- a/backend/my_app/api/v2/models/parcel.py
+++ b/backend/my_app/api/v2/models/parcel.py
@@ -82,15 +82,38 @@ class ParcelModel:
                               parcel_id,
                               'pending delivery')
         cursor.execute(query)
-        return self.db.commit()
+        self.db.commit()
+        parcel = self.get_one_parcel(parcel_id)
+        return parcel
 
-    def change_present_location(self, parcel_id, current_location):
+    def change_present_location(self, current_location, parcel_id):
         """This function changes the status of a parcel"""
         cursor = self.db.cursor(cursor_factory=RealDictCursor)
         query = """UPDATE parcels
                    SET current_location = '{}'
                    WHERE parcel_id = {}
-                   """.format(parcel_id,
-                              current_location)
+                   """.format(current_location,
+                              parcel_id)
         cursor.execute(query)
-        return self.db.commit()
+        self.db.commit()
+        parcel = self.get_one_parcel(parcel_id)
+        return parcel
+
+    def change_destination(self, destination, parcel_id):
+        """
+        This method updates the destination of a parcel
+        :param parcel_id:
+        :param destination:
+        :return: Returns none
+        """
+        cursor = self.db.cursor(cursor_factory=RealDictCursor)
+        query = """UPDATE parcels
+                           SET destination = '{}'
+                           WHERE parcel_id = {}
+                           AND status = '{}'
+                           """.format(destination,
+                                      parcel_id,
+                                      'pending delivery')
+        cursor.execute(query)
+        parcel = self.get_one_parcel(parcel_id)
+        return parcel


### PR DESCRIPTION
#### What does this PR do?
Add an endpoint to change the destination of a parcel 

#### Description of Task to be completed?
Create an endpoint for a user to change the destination of a parcel order if a parcel order is yet to be delivered
`/parcels/<parcel_id>/destination` - `PUT`

**Expected payload**
```
{
	"location":"Garisa"
}
```
**Other updates**
- Update change status, change the present location to return updated information

#### How should this be manually tested?
- on a running instance of the app and access the url as shown above and pass a similar payload

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162031487](https://www.pivotaltracker.com/story/show/162031487)

#### Screenshot
![pr11b](https://user-images.githubusercontent.com/5704600/48880720-be12c500-ee22-11e8-8bb0-911fc7aeef4c.png)
![pr11a](https://user-images.githubusercontent.com/5704600/48880722-be12c500-ee22-11e8-99ff-fde2ffc12b4b.png)
