### PR TITLE
#162031584 add cancel an order endpoint,

### DIFF
--- a/backend/my_app/api/v2/__init__.py
+++ b/backend/my_app/api/v2/__init__.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 from flask_restful import Api
 from .views.auth_views import Register, Login
-from .views.parcel_views import (Parcels, ChangeStatus,
+from .views.parcel_views import (Parcels, ChangeStatus, CancelOrder,
                                  ChangePresentLocation, ChangeDestination)
 
 version2_bp_auth = Blueprint('api_v2', __name__)
@@ -16,3 +16,4 @@ api_v2.add_resource(Parcels, '/parcels')
 api_v2.add_resource(ChangeStatus, '/parcels/<parcel_id>/status')
 api_v2.add_resource(ChangePresentLocation, '/parcels/<parcel_id>/presentLocation')
 api_v2.add_resource(ChangeDestination, '/parcels/<parcel_id>/destination')
+api_v2.add_resource(CancelOrder, '/parcels/<parcel_id>/cancel')

--- a/backend/my_app/api/v2/models/parcel.py
+++ b/backend/my_app/api/v2/models/parcel.py
@@ -61,7 +61,7 @@ class ParcelModel:
     def get_one_parcel(self, parcel_id):
         """
         Takes in a user and returns a user
-        :param email:
+        :param parcel_id:
         :return: Returns a user
         """
         cursor = self.db.cursor(cursor_factory=RealDictCursor)
@@ -104,7 +104,7 @@ class ParcelModel:
         This method updates the destination of a parcel
         :param parcel_id:
         :param destination:
-        :return: Returns none
+        :return: Returns parcel
         """
         cursor = self.db.cursor(cursor_factory=RealDictCursor)
         query = """UPDATE parcels
@@ -115,5 +115,24 @@ class ParcelModel:
                                       parcel_id,
                                       'pending delivery')
         cursor.execute(query)
+        parcel = self.get_one_parcel(parcel_id)
+        return parcel
+
+    def cancel_order(self, parcel_id):
+        """
+        This function cancels an order if it is yet to be delivered
+        :param parcel_id:
+        :return: Returns a parcel
+        """
+        cursor = self.db.cursor(cursor_factory=RealDictCursor)
+        query = """UPDATE parcels
+                           SET status = '{}'
+                           WHERE parcel_id = {}
+                           AND status = '{}'
+                           """.format('cancelled',
+                                      parcel_id,
+                                      'pending delivery')
+        cursor.execute(query)
+        self.db.commit()
         parcel = self.get_one_parcel(parcel_id)
         return parcel


### PR DESCRIPTION
#### What does this PR do?
Add an endpoint to cancel a parcel order 

#### Description of Task to be completed?
Create an endpoint for a user to cancel a parcel order if a parcel order is yet to be delivered
`/parcels/<parcel_id>/cancel` - `PUT`

**Other updates**
- Update authorization for change destination endpoint

#### How should this be manually tested?
- on a running instance of the app, and access the url as shown above and pass an id for the parcel to be cancelled

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162031584](https://www.pivotaltracker.com/story/show/162031584)

#### Screenshot
![pr12b](https://user-images.githubusercontent.com/5704600/48885530-aa268d80-ee39-11e8-9209-ce68f9dc9137.png)
![pr12a](https://user-images.githubusercontent.com/5704600/48885531-aa268d80-ee39-11e8-8c5f-d8d0186c6636.png)
